### PR TITLE
updated package name for NPM publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+npm-debug.log
 test.html

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "elementary",
+  "name": "elementary-css",
   "description": "pure css icons",
   "repository": {
     "type": "git",


### PR DESCRIPTION
npm already has a package named "elementary" so renamed to "elementary-css" and then published package:

```
[root@gandalf dev]# npm publish
+ elementary-css@0.3.7
```

can now use:

`npm install elementary-css`